### PR TITLE
Adding a JSHint task, and associated live reloading tasks.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -113,6 +113,17 @@ DojoGenerator.prototype.askFor = function askFor() {
 			return answers.travisci;
 		},
 		'default': process.env.SAUCE_ACCESS_KEY || ''
+	}, {
+		type : 'confirm',
+		name : 'jshint',
+		message : 'Do you want to run JSHint during the build process?',
+		'default' : true
+	},
+	{
+		type : 'confirm',
+		name : 'livereload',
+		message : 'Do you want to enable live reloading on javascript changes for the server task?',
+		'default' : true
 	}];
 
 	this.prompt(prompts, function (props) {
@@ -131,6 +142,8 @@ DojoGenerator.prototype.askFor = function askFor() {
 		this.putSelectorVersion = props.putSelectorVersion;
 		this.xstyleVersion = props.xstyleVersion;
 		this.compression = props.compression;
+		this.jshint = props.jshint;
+		this.livereload = props.livereload;
 		cb();
 	}.bind(this));
 };

--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,7 @@ DojoGenerator.prototype.askFor = function askFor() {
 	var prompts = [{
 		name: 'dojoVersion',
 		message: 'What version of Dojo will be used?',
-		'default': '~1.9.1'
+		'default': '~1.9.2'
 	}, {
 		type: 'checkbox',
 		name: 'features',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -2,6 +2,7 @@
 module.exports = function (grunt) {
 	require('load-grunt-tasks')(grunt, [ 'grunt-*', 'intern-geezer' ]);
 	require('time-grunt')(grunt);
+	
 	var path = require('path');
 
 	var stripComments = /<\!--.*?-->/g,
@@ -50,17 +51,17 @@ module.exports = function (grunt) {
 		connect: {
 			options: {
 				port: 8888,
-				livereload: 35733,
+				<% if (livereload) { %>livereload: 35733,<% } %>
 				hostname: 'localhost'
 			},
-			livereload: {
-                options: {
-                    open: true,
-                    base: [
-                        'src'
-                    ]
-                }
-            },
+			<% if (livereload) { %>livereload: {
+				options: {
+					open: true,
+					base: [
+						'src'
+					]
+				}
+			},<% } %>
 			test: {
 				options: {
 					open: true,
@@ -87,22 +88,22 @@ module.exports = function (grunt) {
 				}]
 			}
 		},
-
-        // Make sure code styles are up to par and there are no obvious mistakes
-        jshint: {
-            options: {
-                jshintrc: '.jshintrc',
-                reporter: require('jshint-stylish')
-            },
-            all: [
-                'Gruntfile.js',
-                'src/<%= appname %>/{,*/}*.js',
-                '!src/<%= appname %>/dojo/*',
-                '!src/<%= appname %>/dijit/*',
-                '!src/<%= appname %>/dojox/*'
-                //'test/spec/{,*/}*.js'
-            ]
-        },<% if (stylus) { %>
+		<% if (jshint) { %>
+		// Make sure code styles are up to par and there are no obvious mistakes
+		jshint: {
+			options: {
+				jshintrc: '.jshintrc',
+				reporter: require('jshint-stylish')
+			},
+			all: [
+				'Gruntfile.js',
+				'src/<%= appname %>/{,*/}*.js',
+				'!src/<%= appname %>/dojo/*',
+				'!src/<%= appname %>/dijit/*',
+				'!src/<%= appname %>/dojox/*'
+				//'test/spec/{,*/}*.js'
+			]
+		},<% } %><% if (stylus) { %>
 		stylus: {
 			compile: {
 				options: {
@@ -115,27 +116,27 @@ module.exports = function (grunt) {
 			}
 		},<% } %>
 		watch: {
-			js: {
-                files: ['src/<%= appname %>/{,*/}*.js'],
-                tasks: ['jshint'],
-                options: {
-                    livereload: true
-                }
-            },
-            gruntfile: {
-                files: ['Gruntfile.js']
-            },
-            livereload: {
-                options: {
-                    livereload: '<%%= connect.options.livereload %>'
-                },
-                files: [
-                    'src/{,*/}*.html',
-                    'src/<%= appname %>/styles/{,*/}*.css',
+			<% if (jshint) { %>js: {
+				files: ['src/<%= appname %>/{,*/}*.js'],
+				tasks: ['jshint'],
+				options: {
+					livereload: <%= livereload %>
+				}
+			},<% } %>
+			gruntfile: {
+				files: ['Gruntfile.js']
+			},
+			<% if (livereload) { %>livereload: {
+				options: {
+					livereload: '<%%= connect.options.livereload %>'
+				},
+				files: [
+					'src/{,*/}*.html',
+					'src/<%= appname %>/styles/{,*/}*.css',
 					'src/<%= appname %>/{,*/}*.js',
-                    'src/<%= appname %>/images/{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
-                ]
-            }<% if (stylus) { %>,
+					'src/<%= appname %>/images/{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
+				]
+			},<% } %><% if (stylus) { %>
 			stylus: {
 				files: 'src/<%= appname %>/resources/**/*.styl',
 				tasks: [ 'stylus:compile' ]
@@ -160,7 +161,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default',
 		[
 			<% if (stylus) { %>'stylus:compile',<% } %>
-			'jshint',
+			<% if (jshint) { %>'jshint',<% } %>
 			'watch'
 		]
 	);
@@ -175,9 +176,9 @@ module.exports = function (grunt) {
 
 		grunt.task.run(
 			[
-				'jshint',
+				<% if (jshint) { %>'jshint',<% } %>
 				<% if (stylus) { %>'stylus:compile',
-				<% } %>'connect:livereload<% if (!stylus) { %>:keepalive<% } %>',
+				<% } %>'connect:test<% if (livereload) { %>:livereload<% } %><% if (!stylus) { %>:keepalive<% } %>',
 				'watch'
 			]
 		);
@@ -186,7 +187,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('build',
 		[
 			<% if (stylus) { %>'stylus:compile',<% } %>
-			'jshint',
+			<% if (jshint) { %>'jshint',<% } %>
 			'clean',
 			'dojo:dist',
 			'copy'

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,6 +15,5 @@
     "jshint-stylish" : "~0.1.3",
     "intern-geezer": "~1.3.2",
     "load-grunt-tasks": "~0.2.0"
-
   }
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,10 +6,15 @@
     "grunt-dojo": "~0.2.4",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-connect": "~0.5.0",
-    "grunt-contrib-clean": "~0.5.0",<% if (stylus) { %>
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-watch": "~0.5.3",<% if (stylus) { %>
     "grunt-contrib-stylus": "~0.8.0",<% } %>
+    "grunt-contrib-jshint": ">=0.7.0",
+    "grunt-newer" : "~0.6.0",
+    "time-grunt" : "~0.2.0",
+    "jshint-stylish" : "~0.1.3",
     "intern-geezer": "~1.3.2",
-    "load-grunt-tasks": "~0.1.0"
+    "load-grunt-tasks": "~0.2.0"
+
   }
 }

--- a/tests/creation.js
+++ b/tests/creation.js
@@ -40,12 +40,14 @@ define([
 				];
 
 			helpers.mockPrompt(app, {
-				'dojoVersion': '1.9.1',
+				'dojoVersion': '1.9.2',
 				'features': [ 'dijit', 'dgrid', 'stylus' ],
 				'dgridVersion': '0.3.10',
 				'nib': true,
 				'compression': 'closure',
-				'travisci': false
+				'travisci': false,
+				'jshint' : true,
+				'livereload' : true
 			});
 			app.options['skip-install'] = true;
 			app.run({}, function () {


### PR DESCRIPTION
Added a JSHint task to grunt, and updated watch tasks to cause JSHint to
be re-run every time a js file is saved in the directory.  And, added
that "open" flag to the server command, so the site auto-loads in your
default web browser.

Finally, this updates the the default version of dojo to the latest
patch release (1.9.2).
