### PR TITLE
update to Dojo 1.10.0 and dgrid 0.3.15

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,7 @@ DojoGenerator.prototype.askFor = function askFor() {
 	var prompts = [{
 		name: 'dojoVersion',
 		message: 'What version of Dojo will be used?',
-		'default': '~1.9.1'
+		'default': '~1.10.0'
 	}, {
 		type: 'checkbox',
 		name: 'features',
@@ -70,7 +70,7 @@ DojoGenerator.prototype.askFor = function askFor() {
 		name: 'dgridVersion',
 		message: 'What version of dgrid?',
 		when: dgridIncluded,
-		'default': '~0.3.10'
+		'default': '~0.3.15'
 	}, {
 		type: 'confirm',
 		name: 'nib',


### PR DESCRIPTION
Update recommended/default version of the Dojo Toolkit to be 1.10.0 and
version 0.3.15 of dgrid.
